### PR TITLE
Remove dependency on cssify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-view-nodelist",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "canjs-plugin",
@@ -55,7 +45,6 @@
   "devDependencies": {
     "bit-docs": "0.0.7",
     "jshint": "^2.9.1",
-    "cssify": "^1.0.2",
     "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.16.0",


### PR DESCRIPTION
This project doesn't use cssify, including the package.json metadata
breaks Browserify users.