### PR TITLE
Unregister newDeepChildren

### DIFF
--- a/can-view-nodelist.js
+++ b/can-view-nodelist.js
@@ -379,6 +379,13 @@ var nodeLists = {
 			}
 		}
 
+		var newDeepChildren = nodeList.newDeepChildren;
+		if (newDeepChildren) {
+			for (var m = 0; m < newDeepChildren.length; m++) {
+				nodeLists.unregister(newDeepChildren[m], true);
+			}
+		}
+
 		return nodes;
 	},
 

--- a/test/can-view-nodelist-test.js
+++ b/test/can-view-nodelist-test.js
@@ -56,3 +56,24 @@ test('unregisters child nodeLists', function () {
 
 	QUnit.ok(labelList.isUnregistered, "labelList was unregistered");
 });
+
+test('unregisters newDeepChildren', function () {
+	expect(3);
+
+	var list1 = [];
+	var list2 = [
+		document.createTextNode("1"),
+		document.createTextNode("2")
+	];
+
+	nodeLists.register( list1, null, true );
+	nodeLists.register( list2, function() {
+		ok(true, "unregistered list2");
+	}, list1 );
+
+	QUnit.equal(list1.newDeepChildren[0].length, 2, "correct number of newDeepChildren");
+
+	nodeLists.update(list1, [document.createTextNode("3")]);
+
+	QUnit.ok(list2.isUnregistered, "list2 was unregistered");
+});


### PR DESCRIPTION
This fixes an issue where nodes added to `newDeepChildren` weren’t being unregistered.

Fixes https://github.com/canjs/can-component/issues/276