### PR TITLE
Only remove elements that are children of their parent

### DIFF
--- a/can-view-nodelist.js
+++ b/can-view-nodelist.js
@@ -483,8 +483,12 @@ var nodeLists = {
 	 */
 	remove: function(elementsToBeRemoved){
 		var parent = elementsToBeRemoved[0] && elementsToBeRemoved[0].parentNode;
+		var child;
 		for (var i = 0; i < elementsToBeRemoved.length; i++) {
-			domMutate.removeChild.call(parent, elementsToBeRemoved[i]);
+			child = elementsToBeRemoved[i];
+			if(child.parentNode === parent) {
+				domMutate.removeChild.call(parent, child);
+			}
 		}
 	},
 	nodeMap: nodeMap

--- a/test/can-view-nodelist-test.js
+++ b/test/can-view-nodelist-test.js
@@ -56,3 +56,19 @@ test('unregisters child nodeLists', function () {
 
 	QUnit.ok(labelList.isUnregistered, "labelList was unregistered");
 });
+
+QUnit.test(".remove doesn't remove elements not in the parent", function() {
+	var notIn = document.createTextNode("test");
+
+	var parent = document.createElement("div");
+	parent.appendChild(document.createElement("span"));
+	parent.appendChild(document.createElement("section"));
+
+	try {
+		nodeLists.remove([parent.firstChild, notIn, parent.firstChild.nextSibling]);
+
+		QUnit.equal(parent.firstChild, null, "No children now");
+	} catch(err) {
+		QUnit.ok(false, err);
+	}
+});


### PR DESCRIPTION
Without this check, it will throw if a nodelist is passed in that
contains children not part of the parent.